### PR TITLE
Remove access to Monaca CDN.

### DIFF
--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -64,7 +64,6 @@
     <script type="text/javascript" charset="utf-8" src="//c.k3r.jp"></script>
   {{/is}}
     <link rel="stylesheet" href="/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdn.monaca.io/css/monaca-components.min.css">
     <link rel="stylesheet" href="/css/style.css">
 
     <link rel="shortcut icon" href="/img/favicon.ico">


### PR DESCRIPTION
Related: https://github.com/monaca/server/issues/8

`templates/layouts/default.hbs` is used in the two following pages:
- https://ja.monaca.io/book/001/
- https://ja.monaca.io/book/support/

I checked that removing
```html
<link rel="stylesheet" href="https://cdn.monaca.io/css/monaca-components.min.css">
```
did not affect the behavior of each page.
And also Chrome DevTools Audits (Lighthouse) said that 100% of `monaca-components.min.css` can be removed.
Therefore I think it is safe to include this change.