### PR TITLE
MN-933 fix: use Ajax instead of `script` element to access API server.

### DIFF
--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -157,17 +157,32 @@
   <script defer src="/js/all.js"></script>
   <script defer src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
 {{#is class "error"}}
+  {{!-- In error page --}}
   <script>
     window.addEventListener('DOMContentLoaded', function() {
-      monacaApi.loginCheck(false); // Force to stop login check request When web-server error
+      // Skip login check when API server is down
+      monacaApi.loginCheck(false);
     });
   </script>
 {{else}}
-  {{#is language "ja"}}
-  <script defer src="{{site.monaca_api}}/ja/login_io?callback=monacaApi.loginCheck"></script>
-  {{else}}
-  <script defer src="{{site.monaca_api}}/en/login_io?callback=monacaApi.loginCheck"></script>
-  {{/is}}
+  {{!-- In normal page --}}
+  <script>
+    window.addEventListener('DOMContentLoaded', function() {
+      // Login check + IP address country check
+      $.ajax({
+        url: '{{site.monaca_api}}/{{language}}/login_io',
+        dataType: 'json',
+        timeout: 2000,
+        success: function(data, textStatus, jqXHR) {
+          monacaApi.loginCheck(data);
+        },
+        error: function(jqXHR, textStatus, err) {
+          // If request failed or response is not valid JSON
+          monacaApi.loginCheck(false); // Assume that not logged in
+        }
+      });
+    });
+  </script>
 {{/is}}
 </head>
 

--- a/src/templates/layouts/index.hbs
+++ b/src/templates/layouts/index.hbs
@@ -116,10 +116,33 @@
   <script defer src="/js/jquery.min.js"></script>
   <script defer src="/js/bootstrap.min.js"></script>
   <script defer src="/js/all.js"></script>
-{{#is language "ja"}}
-  <script defer src="{{site.monaca_api}}/ja/login_io?callback=monacaApi.loginCheck"></script>
+{{#is class "error"}}
+  {{!-- In error page --}}
+  <script>
+    window.addEventListener('DOMContentLoaded', function() {
+      // Skip login check when API server is down
+      monacaApi.loginCheck(false);
+    });
+  </script>
 {{else}}
-  <script defer src="{{site.monaca_api}}/en/login_io?callback=monacaApi.loginCheck"></script>
+  {{!-- In normal page --}}
+  <script>
+    window.addEventListener('DOMContentLoaded', function() {
+      // Login check + IP address country check
+      $.ajax({
+        url: '{{site.monaca_api}}/{{language}}/login_io',
+        dataType: 'json',
+        timeout: 2000,
+        success: function(data, textStatus, jqXHR) {
+          monacaApi.loginCheck(data);
+        },
+        error: function(jqXHR, textStatus, err) {
+          // If request failed or response is not valid JSON
+          monacaApi.loginCheck(false); // Assume that not logged in
+        }
+      });
+    });
+  </script>
 {{/is}}
 </head>
 <body class="{{class}}">


### PR DESCRIPTION
This PR fixes this bug:
- When API server is down or returns invalid JSON, every page (except for error pages like `error404.html`) is not shown.
